### PR TITLE
Implement persistence forecasting

### DIFF
--- a/forecasting/pv_forecast_dev.py
+++ b/forecasting/pv_forecast_dev.py
@@ -214,116 +214,6 @@ def calc_ratio(X, Y):
     return ratio
 
 
-def _align_data_to_forecast(start, end, deltat, history, target_offset):
-    """
-
-    Returns
-    ---------
-    idata : pandas DataFrame
-
-    """
-    # number of intervals with length deltat between start of history and
-    # start of forecast
-    num_intervals = int(
-              (fstart - min(history.index)).total_seconds() / deltat.seconds)
-
-    # interpolate history to new datetime index idr with interval deltat
-    # and starting in phase with forecast
-    idr = pd.DatetimeIndex(fstart - num_intervals*deltat,
-                           end=end,
-                           freq=target_offset)
-    tmpdata = pd.DataFrame(index=idr, data=np.nan, columns=['ac_power'])
-
-    # merge history with empty dataframe that has the index we want
-    newdata = tmpdata.merge(history.to_frame(),
-                            how='outer',
-                            on=['ac_power'],
-                            left_index=True,
-                            right_index=True).tz_convert(tmpdata.index.tz)
-
-    # fill in values on idr timesteps by interpolation
-    newdata.interpolate(inplace=True)
-
-    # trim to start at first index in idr (in phase with forecast start),
-    # and don't overrun history
-    idata = newdata[(newdata.index>=min(idr)) &
-                    (newdata.index<=max(history.index))].copy()
-
-    # calculates minutes out of phase with midnight
-    base = int((idr[0].replace(hour=0, second=0) -
-                idr[0].normalize()).total_seconds() / 60)
-
-    # want time averages in phase with forecast start over specified deltat.
-    idata = idata.resample(target_offset,
-                           closed='left',
-                           label='left',
-                           base=base).mean()
-
-    return idata, idr
-
-
-def _select_data_for_forecast(pvobj, start, end, deltat, history,
-                              dataWindowLength):
-
-    """
-    Align history data with forecast start time and time interval.
-    Uses linear interpolation for values between those in history.
-
-    Parameters
-    -----------
-
-    pvobj : an instance of type PVobj
-
-    start : datetime
-        the time for the first forecast value
-
-    end : datetime
-        the last time to be forecast
-
-    deltat : timedelta
-        the time interval for the forecast
-
-    history : pandas DataFrame with key 'ac_power'
-        historical values of AC power from which the forecast is made.
-
-    dataWindowLenth : timedelta
-        time interval in history to be considered
-
-    Returns
-    ----------
-    fitdata :
-        data from history aligned to be in phase with requested forecast
-
-    fdr : pandas DatetimeIndex
-        time index for requested forecast
-
-    steps : integer
-        number of time steps in the forecast forecast
-    """
-
-    # datetime index for history
-    target_offset = pd.to_timedelta(deltat)
-
-    # create datetime index for forecast
-    fdr = pd.DatetimeIndex(start=start, end=end, freq=target_offset)
-
-    idata, idr = _align_data_to_forecast(start, end, deltat, history)
-
-
-    # select data within dataWindowLength
-    end_data_time = max(idata.index)
-    first_data_time = end_data_time - dataWindowLength
-    fitdata = idata.loc[(idata.index>=first_data_time) &
-                        (idata.index<=end_data_time)]
-
-    # determine number of intervals for forecast. start with first interval
-    # after the data used to fit the model. +1 because steps counts intervals
-    # we want the interval after the last entry in fdr
-    f_intervals = len(idr[idr>max(fitdata.index)]) + 1
-
-    return fitdata, fdr, f_intervals
-
-
 def forecast_persistence(pvobj, start, end, deltat, history, order=None,
              dataWindowLength=timedelta(hours=1)):
 
@@ -373,6 +263,167 @@ def forecast_persistence(pvobj, start, end, deltat, history, order=None,
 
     # convert forecast of ac_power_index to forecast of ac_power
 
+def _extend_datetime_index(start, end, deltat, earlier):
+    """
+    Extends a datetime index from  ``start`` to ``end`` at
+    interval ``deltat`` to begin prior to ``earlier`` time.
+    
+    Parameters
+    -------------
+    start : datetime
+        the start time for the datetime index
+        
+    end : datetime
+        the end time for the datetime index
+        
+    deltat : timedelta
+        the time interval for the datetime index
+    
+    earlier : datetime
+        earlier time to include in the extended datetime index
+        
+    Returns
+    ------------
+    idr : DateTimeIndex
+        start replaced by earlier time, time interval and end time maintained
+        
+    """
+    if earlier > start:
+        raise Exception("Error in _extend_datetime_index: earlier > start")
+        return
+    
+    # number of intervals with length deltat between start of input
+    # datetime index and the earlier time to be included
+    num_intervals = int(
+              (start - earlier).total_seconds() / deltat.seconds)
+
+    # extend datetime index to include earlier time
+    idr = pd.DatetimeIndex(start=(start - num_intervals*deltat),
+                           end=end,
+                           freq=pd.to_timedelta(deltat))
+
+    return idr
+
+    
+def _align_data_to_forecast(fstart, fend, deltat, history):
+    """
+    Interpolate history to times that are in phase with forecast
+    
+    Parameters
+    -----------
+    fstart : datetime
+        first time for the forecast
+        
+    fend : datetime
+        end time for the forecast
+    
+    deltat : timedelta
+        interval for the forecast
+    
+    history : pandas Series or DataFrame containing key 'ac_power'
+        measurements to use for the forecast
+        
+    Returns
+    ---------
+    idata : pandas DataFrame
+        contains history interpolated to times that are in phase with requested
+        forecast times
+        
+    idr : pandas DatetimeIndex
+        datetime index that includes history and forecast periods and is in
+        phase with forecast times
+        
+    """
+    
+    idr = _extend_datetime_index(fstart, fend, deltat, min(history.index))
+    
+    tmpdata = pd.DataFrame(index=idr, data=np.nan, columns=['ac_power'])
+
+    # merge history into empty dataframe that has the index we want
+    # use outer join to retain time points in history
+    newdata = tmpdata.merge(history.to_frame(),
+                            how='outer',
+                            on=['ac_power'],
+                            left_index=True,
+                            right_index=True).tz_convert(tmpdata.index.tz)
+
+    # fill in values on idr timesteps by interpolation
+    newdata.interpolate(inplace=True)
+
+    # trim to start at first index in idr (in phase with forecast start),
+    # and don't overrun history
+    idata = newdata[(newdata.index>=min(idr)) &
+                    (newdata.index<=max(history.index))].copy()
+
+    # calculates minutes out of phase with midnight
+    base = int((idr[0].replace(hour=0, second=0) -
+                idr[0].normalize()).total_seconds() / 60)
+
+    # want time averages in phase with forecast start over specified deltat.
+    idata = idata.resample(pd.to_timedelta(deltat),
+                           closed='left',
+                           label='left',
+                           base=base).mean()
+
+    return idata, idr
+
+
+def _get_data_for_forecast(pvobj, start, end, deltat, history,
+                              dataWindowLength):
+
+    """
+    Returns interpolated history data in phase with forecast start time and
+    time interval.
+
+    Parameters
+    -----------
+
+    pvobj : an instance of type PVobj
+
+    start : datetime
+        the time for the first forecast value
+
+    end : datetime
+        the last time to be forecast
+
+    deltat : timedelta
+        the time interval for the forecast
+
+    history : pandas DataFrame with key 'ac_power'
+        historical values of AC power from which the forecast is made.
+
+    dataWindowLenth : timedelta
+        time interval in history to be considered
+
+    Returns
+    ----------
+    fitdata :
+        data from history aligned to be in phase with requested forecast
+
+    fdr : pandas DatetimeIndex
+        time index for requested forecast
+
+    steps : integer
+        number of time steps in the forecast forecast
+    """
+
+    # align history data with forecast start time and interval
+    idata, idr = _align_data_to_forecast(start, end, deltat, history)
+
+    # select aligned data within dataWindowLength
+    end_data_time = max(idata.index)
+    first_data_time = end_data_time - dataWindowLength
+    fitdata = idata.loc[(idata.index>=first_data_time) &
+                        (idata.index<=end_data_time)]
+
+    # determine number of intervals for forecast. start with first interval
+    # after the data used to fit the model. +1 because steps counts intervals
+    # we want the interval after the last entry in fdr
+    f_intervals = len(idr[idr>max(fitdata.index)]) + 1
+
+    return fitdata, f_intervals
+
+
 
 def forecast_ARMA(pvobj, start, end, deltat, history, order=None,
                   dataWindowLength=timedelta(hours=1)):
@@ -408,9 +459,9 @@ def forecast_ARMA(pvobj, start, end, deltat, history, order=None,
 
     # TODO: input validation
 
-    fitdata, fdr, f_intervals = _select_data_for_forecast(pvobj, start, end,
-                                                          deltat, history,
-                                                          dataWindowLength)
+    fitdata, f_intervals = _get_data_for_forecast(pvobj, start, end,
+                                                       deltat, history,
+                                                       dataWindowLength)
 
     # TODO: model identification logic
 
@@ -435,6 +486,9 @@ def forecast_ARMA(pvobj, start, end, deltat, history, order=None,
     results = model.fit()
 
     f = results.forecast(f_intervals)
+
+    # create datetime index for forecast
+    fdr = pd.DatetimeIndex(start=start, end=end, freq=pd.to_timedelta(deltat))
 
     return f[fdr]
 

--- a/forecasting/pv_forecast_dev.py
+++ b/forecasting/pv_forecast_dev.py
@@ -1,7 +1,6 @@
 #from generic_vpp_server import GenericVPPServer
 #from multiprocessing import Manager
-import time, sys
-import os
+
 import pvlib
 import pytz
 from datetime import datetime
@@ -10,7 +9,6 @@ import pandas as pd
 import numpy as np
 import statsmodels.api as sm
 import matplotlib.pyplot as plt
-import matplotlib.ticker as mtick
 import matplotlib.dates as mdates
 
 class PVobj():
@@ -102,9 +100,184 @@ def solar_position(pvobj, dr):
                                        pvobj.timezone,
                                        pvobj.alt)
 
-    sp = pvlib.solarposition.ephemeris(dr, Location.latitude, Location.longitude)
+    sp = ephemeris(dr, Location.latitude, Location.longitude)
 
     return sp
+
+
+def ephemeris(time, latitude, longitude, pressure=101325, temperature=12):
+    """
+    Python-native solar position calculator.  Included here from pvlib until
+    performance improvement is made in pvlib source.
+
+    Parameters
+    ----------
+    time : pandas.DatetimeIndex
+    latitude : float
+    longitude : float
+    pressure : float or Series, default 101325
+        Ambient pressure (Pascals)
+    temperature : float or Series, default 12
+        Ambient temperature (C)
+
+    Returns
+    -------
+
+    DataFrame with the following columns:
+
+        * apparent_elevation : apparent sun elevation accounting for
+          atmospheric refraction.
+        * elevation : actual elevation (not accounting for refraction)
+          of the sun in decimal degrees, 0 = on horizon.
+          The complement of the zenith angle.
+        * azimuth : Azimuth of the sun in decimal degrees East of North.
+          This is the complement of the apparent zenith angle.
+        * apparent_zenith : apparent sun zenith accounting for atmospheric
+          refraction.
+        * zenith : Solar zenith angle
+        * solar_time : Solar time in decimal hours (solar noon is 12.00).
+
+    References
+    -----------
+
+    Grover Hughes' class and related class materials on Engineering
+    Astronomy at Sandia National Laboratories, 1985.
+
+    See also
+    --------
+    pyephem, spa_c, spa_python
+
+    """
+
+    # Added by Rob Andrews (@Calama-Consulting), Calama Consulting, 2014
+    # Edited by Will Holmgren (@wholmgren), University of Arizona, 2014
+
+    # Most comments in this function are from PVLIB_MATLAB or from
+    # pvlib-python's attempt to understand and fix problems with the
+    # algorithm. The comments are *not* based on the reference material.
+    # This helps a little bit:
+    # http://www.cv.nrao.edu/~rfisher/Ephemerides/times.html
+
+    # the inversion of longitude is due to the fact that this code was
+    # originally written for the convention that positive longitude were for
+    # locations west of the prime meridian. However, the correct convention (as
+    # of 2009) is to use negative longitudes for locations west of the prime
+    # meridian. Therefore, the user should input longitude values under the
+    # correct convention (e.g. Albuquerque is at -106 longitude), but it needs
+    # to be inverted for use in the code.
+
+    Latitude = latitude
+    Longitude = -1 * longitude
+
+    Abber = 20 / 3600.
+    LatR = np.radians(Latitude)
+
+    # the SPA algorithm needs time to be expressed in terms of
+    # decimal UTC hours of the day of the year.
+
+    # if localized, convert to UTC. otherwise, assume UTC.
+    try:
+        time_utc = time.tz_convert('UTC')
+    except TypeError:
+        time_utc = time
+
+    # strip out the day of the year and calculate the decimal hour
+    DayOfYear = time_utc.dayofyear
+    DecHours = (time_utc.hour + time_utc.minute/60. + time_utc.second/3600. +
+                time_utc.microsecond/3600.e6)
+
+    # np.array needed for pandas > 0.20
+    UnivDate = np.array(DayOfYear)
+    UnivHr = np.array(DecHours)
+
+    Yr = np.array(time_utc.year) - 1900
+    YrBegin = 365 * Yr + np.floor((Yr - 1) / 4.) - 0.5
+
+    Ezero = YrBegin + UnivDate
+    T = Ezero / 36525.
+
+    # Calculate Greenwich Mean Sidereal Time (GMST)
+    GMST0 = 6 / 24. + 38 / 1440. + (
+        45.836 + 8640184.542 * T + 0.0929 * T ** 2) / 86400.
+    GMST0 = 360 * (GMST0 - np.floor(GMST0))
+    GMSTi = np.mod(GMST0 + 360 * (1.0027379093 * UnivHr / 24.), 360)
+
+    # Local apparent sidereal time
+    LocAST = np.mod((360 + GMSTi - Longitude), 360)
+
+    EpochDate = Ezero + UnivHr / 24.
+    T1 = EpochDate / 36525.
+
+    ObliquityR = np.radians(
+        23.452294 - 0.0130125 * T1 - 1.64e-06 * T1 ** 2 + 5.03e-07 * T1 ** 3)
+    MlPerigee = 281.22083 + 4.70684e-05 * EpochDate + 0.000453 * T1 ** 2 + (
+        3e-06 * T1 ** 3)
+    MeanAnom = np.mod((358.47583 + 0.985600267 * EpochDate - 0.00015 *
+                       T1 ** 2 - 3e-06 * T1 ** 3), 360)
+    Eccen = 0.01675104 - 4.18e-05 * T1 - 1.26e-07 * T1 ** 2
+    EccenAnom = MeanAnom
+    E = 0
+
+    while np.max(abs(EccenAnom - E)) > 0.0001:
+        E = EccenAnom
+        EccenAnom = MeanAnom + np.degrees(Eccen)*np.sin(np.radians(E))
+
+    TrueAnom = (
+        2 * np.mod(np.degrees(np.arctan2(((1 + Eccen) / (1 - Eccen)) ** 0.5 *
+                   np.tan(np.radians(EccenAnom) / 2.), 1)), 360))
+    EcLon = np.mod(MlPerigee + TrueAnom, 360) - Abber
+    EcLonR = np.radians(EcLon)
+    DecR = np.arcsin(np.sin(ObliquityR)*np.sin(EcLonR))
+
+    RtAscen = np.degrees(np.arctan2(np.cos(ObliquityR)*np.sin(EcLonR),
+                                    np.cos(EcLonR)))
+
+    HrAngle = LocAST - RtAscen
+    HrAngleR = np.radians(HrAngle)
+    HrAngle = HrAngle - (360 * ((abs(HrAngle) > 180)))
+
+    SunAz = np.degrees(np.arctan2(-np.sin(HrAngleR),
+                                  np.cos(LatR)*np.tan(DecR) -
+                                  np.sin(LatR)*np.cos(HrAngleR)))
+    SunAz[SunAz < 0] += 360
+
+    SunEl = np.degrees(np.arcsin(
+        np.cos(LatR) * np.cos(DecR) * np.cos(HrAngleR) +
+        np.sin(LatR) * np.sin(DecR)))
+
+    SolarTime = (180 + HrAngle) / 15.
+
+    # Calculate refraction correction
+    Elevation = SunEl
+    TanEl = pd.Series(np.tan(np.radians(Elevation)), index=time_utc)
+    Refract = pd.Series(0, index=time_utc)
+
+    Refract[(Elevation > 5) & (Elevation <= 85)] = (
+        58.1/TanEl - 0.07/(TanEl**3) + 8.6e-05/(TanEl**5))
+
+    Refract[(Elevation > -0.575) & (Elevation <= 5)] = (
+        Elevation *
+        (-518.2 + Elevation*(103.4 + Elevation*(-12.79 + Elevation*0.711))) +
+        1735)
+
+    Refract[(Elevation > -1) & (Elevation <= -0.575)] = -20.774 / TanEl
+
+    Refract *= (283/(273. + temperature)) * (pressure/101325.) / 3600.
+
+    ApparentSunEl = SunEl + Refract
+
+    # make output DataFrame
+    DFOut = pd.DataFrame(index=time_utc)
+    DFOut['apparent_elevation'] = ApparentSunEl
+    DFOut['elevation'] = SunEl
+    DFOut['azimuth'] = SunAz
+    DFOut['apparent_zenith'] = 90 - ApparentSunEl
+    DFOut['zenith'] = 90 - SunEl
+    DFOut['solar_time'] = SolarTime
+
+    DFOut.index = time
+    
+    return DFOut
 
 
 def dniDiscIrrad(weather):
@@ -304,16 +477,18 @@ def convert_to_time_of_year(dr):
         time of year in seconds
 
     """
-    # get series of earliest time in each corresponding year
-    base_times = pd.DatetimeIndex([d.replace(month=1,
-                                             day=1,
-                                             hour=0,
-                                             minute=0,
-                                             second=0,
-                                             microsecond=0,
-                                             nanosecond=0) for d in dr])
+    
+    # create series of earliest time in each corresponding year
+    time_of_year = pd.Series(index=dr, data=dr)
+    base_times = pd.to_datetime({'year': time_of_year.dt.year,
+                                 'month': 1, 
+                                 'day': 1,
+                                 'hour': 0,
+                                 'minute': 0,
+                                 'second': 0})
+    base_times = base_times.dt.tz_localize(dr.tz)
 
-    time_of_year = (dr - base_times).total_seconds()
+    time_of_year = (dr - base_times).dt.total_seconds()
 
     return time_of_year
 
@@ -910,10 +1085,14 @@ if __name__ == "__main__":
         plt.show()
 
         pvobj = pvdict['Prosperityx2']
+        
+        # use clearsky model as a surrogate for system data
         hstart = datetime(2016, 1, 3, 0, 0, 30, tzinfo=USMtn)
         hend = datetime(2016, 1, 6, 11, 50, 30, tzinfo=USMtn)
         dat = pvobj.clearsky['ac_power']
         history = dat.loc[(dat.index>=hstart) & (dat.index<hend)]
+
+        # forecast period
         fstart = datetime(2016, 1, 6, 12, 3, 0, tzinfo=USMtn)
         fend = fstart + timedelta(minutes=60)
         fcstP = pvobj.forecast(start=fstart,


### PR DESCRIPTION
This revision to `forecasting\pv_forecast_dev` 

- implements persistence of the clearsky power index as the default forecast method for PV systems.

- retains but refactors the ARMA forecast method.

Close #3 